### PR TITLE
Added required package for installation

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -53,6 +53,7 @@ setup(
     author="txStatsD Developers",
     url="https://launchpad.net/txstatsd",
     license="MIT",
+    install_requires=['Twisted==11.1.0'],
     packages=find_packages() + ["twisted.plugins"],
     scripts=glob("./bin/*"),
     long_description=long_description,


### PR DESCRIPTION
Twisted need to be installed upfront, else pip install will break due to the plugin refresh. 
Same version as in the requirements was taken.
